### PR TITLE
Add cmake to Fedora deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ sudo apt install \
 ### Fedora
 ```
 sudo dnf install \
+	cmake \
 	git \
 	gcc \
 	meson \


### PR DESCRIPTION
When building on Fedora, `cmake` is a required dependency that is not automatically installed (at least on Fedora Workstation 34).  This small PR adds cmake to the Fedora dependency list.